### PR TITLE
Allow to set absolute brightness + custom unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you need more advanced feature:
 - You can set multiple time in the same scheduler: just write them in the field separated by spaces.  
 - You can use the words **sunrise** and **sunset** and also add an offset (in minutes) to it if you need (e.g: **sunrise+30** or **sunset-60** )
 - You can set the brightness of a light. Write **16:30>B30** turn on the light at 30%. 
+- You can set the absolute brightness of a light with an optional unit. Write **16:30>A30xyz** turn on the light at 30 (absolute) and display xyz as unit.
 - You can set the temperature of a climate. Write **16:30>T22.5** to turn on the climate and set the temperature to 22.5° 
 - You can set the temperature of a climate without turning it on. Write **16:30>TO22.5** to set the temperature to 22.5° 
 - You can set the position of a cover. Write **16:30>P25** will set the cover at 25%  

--- a/rootfs/etc/cont-init.d/simplescheduler.sh
+++ b/rootfs/etc/cont-init.d/simplescheduler.sh
@@ -4,7 +4,7 @@
 # Configures requirements
 # ==============================================================================
 
-rm /var/www/html/index.html
+rm -f /var/www/html/index.html
 
 FOLDER=/share/simplescheduler
 

--- a/rootfs/var/www/html/lib.php
+++ b/rootfs/var/www/html/lib.php
@@ -79,7 +79,7 @@ function get_switch_list() {
 }	
 
 
-function call_HA (Array $eid_list, string $action , string $passedvalue="" ) {
+function call_HA (Array $eid_list, string $action , string $type = "", string $passedvalue="" ) {
 
 	global $HASSIO_URL;
 		
@@ -92,7 +92,11 @@ function call_HA (Array $eid_list, string $action , string $passedvalue="" ) {
 			$postdata = "{\"entity_id\":\"$eid\"}" ;
 			
 			if ($domain[0]=="light" && $value!="" ) {
-				$v = (int)((int)$value * 2.55);
+				if ($type == "A") {
+					$v = (int) $value; // absolute
+				} else {
+					$v = (int)((int)$value * 2.55); // relative
+				}
 				$postdata = "{\"entity_id\":\"$eid\",\"brightness\":\"$v\"}" ;
 			}
 			
@@ -319,6 +323,11 @@ function get_html_events_list(string $s,bool $showvalue=true) {
 		if (isset($piece[1]) && $showvalue) {
 			$v = substr(trim($piece[1]), 1);
 			if(strtoupper($piece[1][0])=="F") $extra="<span class=\"event-type-f\"><i class=\"mdi mdi-fan\" aria-hidden=\"true\"></i>$v%</span>";
+			if(strtoupper($piece[1][0])=="A") { // absolute value with custom unit
+				$u=preg_split('/\d+/',$v,2)[1]; // unit is everything after the last digit
+				$v=(int) $v; // remove unit from value
+				$extra="<span class=\"event-type-b\"><i class=\"mdi mdi-lightbulb\" aria-hidden=\"true\"></i>$v $u</span>";
+			}
 			if(strtoupper($piece[1][0])=="B") $extra="<span class=\"event-type-b\"><i class=\"mdi mdi-lightbulb\" aria-hidden=\"true\"></i>$v%</span>";
 			if(strtoupper($piece[1][0])=="P") $extra="<span class=\"event-type-p\"><i class=\"mdi mdi-arrow-up-down\" aria-hidden=\"true\"></i>$v%</span>";
 			if(strtoupper($piece[1][0])=="T") {

--- a/rootfs/var/www/html/scheduler.php
+++ b/rootfs/var/www/html/scheduler.php
@@ -39,17 +39,19 @@
 					if (strpos($s->on_dow,  $current_dow)!== false) :
 						$elist = get_events_array($s->on_tod);
 						foreach($elist as  $e) :
-							$extra = ""; $value = "";
+							$type = ""; $extra = ""; $value = "";
 							$event_time = evaluate_event_time($e,$sun);
 							if ( $event_time==$current_time ) :
 								$extra = get_event_extra_info($e);
+								$type=$extra[0] ;
 								$value=$extra[1] ;
-								call_HA($s->entity_id,"on",$value);
+								call_HA($s->entity_id,"on",$type,$value);
 								foreach ($s->entity_id as $ent_id):
 										$cmd = new stdClass();
 										$cmd->entity_id = $ent_id;
 										$cmd->sched_id = $s->id;
 										$cmd->state = 'on';
+										$cmd->type = $type;
 										$cmd->value = $value;
 										$cmd->countdown = $max_retry;
 										$command_queue[ uniqid()] = $cmd;
@@ -70,6 +72,7 @@
 										$cmd->entity_id = $ent_id;
 										$cmd->sched_id = $s->id;
 										$cmd->state = 'off';
+										$cmd->type = "";
 										$cmd->value = "";
 										$cmd->countdown = $max_retry;
 										$command_queue[ uniqid()] = $cmd;
@@ -93,12 +96,12 @@
 						unset($command_queue[$key]);
 						if ($entity_status!=$value->state & $value->countdown < $max_retry ) {
 								echo '[' . date('r') . "] SCHED:  {$value->entity_id} is available. \n";
-								call_HA(array($value->entity_id),$value->state,$value->value);
+								call_HA(array($value->entity_id),$value->state,$value->type,$value->value);
 						}
 					} else {
 						$attempt = 1 + (int)$max_retry - (int)$value->countdown ;
 						echo '[' . date('r') . "] SCHED:  {$value->entity_id} is unavailable! Attempt $attempt of $max_retry \n";
-						call_HA(array($value->entity_id),$value->state,$value->value);
+						call_HA(array($value->entity_id),$value->state,$value->type,$value->value);
 						$command_queue[$key]->countdown--;
 						if ($command_queue[$key]->countdown <=0) unset($command_queue[$key]);
 				}


### PR DESCRIPTION
Simple implementation for #76 with minimal changes. The expression `21:01>A20min` results in the following presentation. The brightness is set to absolute of 20

![image](https://user-images.githubusercontent.com/186753/184961801-e7294886-c07e-41d4-b99a-773c447f88ca.png)
