### PR TITLE
Add GH action to build and publish a docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,47 @@
+# derived from https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions
+name: Create and publish Docker image
+on:
+  push:
+    branches:
+    - "*"
+    tags:
+    - "*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e # v4.4.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:6.2.6


### PR DESCRIPTION
Hello,

this is a contribution to #126. It adds a github action that checks out the repo, builds the docker image and pushes it directly to github image registry.

No manual work needed, all is automated by github. It will create an image for every branch and every tag that contains this workflow file. You can restrict it to certain tags or branches via the "on...push..." conditions.

It would be nice if you'd start to git-tag versions, so that each new version gets it's own docker image.

Edit: you can see the result at https://github.com/micw/SimpleScheduler/pkgs/container/simplescheduler .
Edit2: GH actions seems to have issues today. If the action falis with no error message, just re-run it.