### PR TITLE
Added callback_api_version to main.py

### DIFF
--- a/rootfs/simplescheduler/main.py
+++ b/rootfs/simplescheduler/main.py
@@ -858,7 +858,7 @@ if __name__ == '__main__':
 
     if options['MQTT']['enabled']:
         printlog('STATUS: Starting MQTT')
-        mqttclient = mqtt.Client(client_id="SimpleScheduler", clean_session=False)
+        mqttclient = mqtt.Client(client_id="SimpleScheduler", clean_session=False, callback_api_version=mqtt.CallbackAPIVersion.VERSION2)
         mqttclient.on_connect = on_connect
         mqttclient.on_message = on_message
         mqttclient.will_set(lwt_topic, payload="offline", qos=0, retain=True)


### PR DESCRIPTION
Added callback_api_version to main.py, to fix the following fatal error during startup of the add-on, after setting up MQTT:

`[2024-02-10 20:51:29] STATUS: Starting MQTT`
`Traceback (most recent call last):`
`  File "/simplescheduler/main.py", line 861, in <module>`
`    mqttclient = mqtt.Client(client_id="SimpleScheduler", clean_session=False)`
`TypeError: __init__() missing 1 required positional argument: 'callback_api_version'`
`[20:51:30] WARNING: example 2 crashed, halting add-on`